### PR TITLE
Add alwaysScroll option to always enable scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ $ npm i react-auto-scroll
 var React = require('react')
 var AutoScroll = require('react-auto-scroll')
 var Component = AutoScroll({
-  property: 'propertyName'
+  property: 'propertyName',
+  alwaysScroll: false
 })(React.createClass(/* ... */))
 ```
 
@@ -25,6 +26,8 @@ var Component = AutoScroll({
 * `AutoScroll(options)(Component)`
 
 * `options.property` (string) Property to track for scrolling
+
+* `options.alwaysScroll` (boolean) Always enable scrolling even if user has scrolled up. Set to `false` by default.
 
 ## License
 

--- a/lib/AutoScroll.js
+++ b/lib/AutoScroll.js
@@ -3,32 +3,34 @@ var ReactDOM = require('react-dom')
 
 module.exports = function AutoScroll (options) {
   var property = options.property
+  var alwaysScroll = options.alwaysScroll || false
 
   return function (Component) {
     var displayName = Component.displayName || Component.name || 'Component'
 
     var propTypes = {}
     propTypes[property] = React.PropTypes.any
+    propTypes[alwaysScroll] = React.PropTypes.bool
 
     var AutoScrollComponent = React.createClass({
       componentDidMount: function componentDidMount () {
         var node = this._node
         node.scrollTop = node.scrollHeight
-        this._shouldScroll = false
+        this._shouldScroll = alwaysScroll || false
       },
 
       componentDidUpdate: function componentDidUpdate (prevProps) {
         if (this._shouldScroll) {
           var node = this._node
           node.scrollTop = node.scrollHeight
-          this._shouldScroll = false
+          this._shouldScroll = alwaysScroll || false
         }
       },
 
       componentWillUpdate: function componentWillUpdate (nextProps) {
         if (this.props[property] !== nextProps[property]) {
           var node = this._node
-          this._shouldScroll = node.scrollTop + node.offsetHeight === node.scrollHeight
+          this._shouldScroll = alwaysScroll || node.scrollTop + node.offsetHeight === node.scrollHeight
         }
       },
 

--- a/lib/AutoScroll.js
+++ b/lib/AutoScroll.js
@@ -23,7 +23,7 @@ module.exports = function AutoScroll (options) {
         if (this._shouldScroll) {
           var node = this._node
           node.scrollTop = node.scrollHeight
-          this._shouldScroll = alwaysScroll || false
+          this._shouldScroll = false
         }
       },
 


### PR DESCRIPTION
Option to always activate the scrolling even if the user scrolled up. Set to `false` by default. Solves issue #1.
