### PR TITLE
Add autoScrollBuffer for the option to lower autoscroll tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ $ npm i react-auto-scroll
 var React = require('react')
 var AutoScroll = require('react-auto-scroll')
 var Component = AutoScroll({
-  property: 'propertyName'
+  property: 'propertyName',
+  autoScrollBuffer: 30
 })(React.createClass(/* ... */))
 ```
 
@@ -25,6 +26,8 @@ var Component = AutoScroll({
 * `AutoScroll(options)(Component)`
 
 * `options.property` (string) Property to track for scrolling
+
+* `options.autoScrollBuffer` (number) Scroll distance from bottom buffer when autoscroll should take effect. Default: `0`
 
 ## License
 

--- a/lib/AutoScroll.js
+++ b/lib/AutoScroll.js
@@ -3,6 +3,7 @@ var ReactDOM = require('react-dom')
 
 module.exports = function AutoScroll (options) {
   var property = options.property
+  var autoScrollBuffer = options.autoScrollBuffer || 0
 
   return function (Component) {
     var displayName = Component.displayName || Component.name || 'Component'
@@ -28,7 +29,7 @@ module.exports = function AutoScroll (options) {
       componentWillUpdate: function componentWillUpdate (nextProps) {
         if (this.props[property] !== nextProps[property]) {
           var node = this._node
-          this._shouldScroll = node.scrollTop + node.offsetHeight === node.scrollHeight
+          this._shouldScroll = node.scrollTop + node.offsetHeight >= node.scrollHeight - autoScrollBuffer
         }
       },
 


### PR DESCRIPTION
In some applications, views may want to still autoscroll if the user has just
bumped the scroll window up by a small margin. This gives them the option to set
a tolerance value for how much the user can scroll before disabling autoscroll.